### PR TITLE
[Fix] Create Custom Config for Blog Posts

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,0 +1,20 @@
+{{ define "main" }}
+{{ if eq .Type "blogg" }}{{ if not .Params.menu }}
+<h1>{{ .Title }}</h1>
+<p>
+  <i>
+    <time datetime='{{ .Date.Format "2006-01-02" }}' pubdate>
+      {{ .Date.Format (default "02 Jan, 2006" .Site.Params.dateFormat) }}
+    </time>
+  </i>
+</p>
+{{ end }}{{ end }}
+<content>
+  {{ .Content }}
+</content>
+<p>
+  {{ range (.GetTerms "tags") }}
+  <a href="{{ .Permalink }}">#{{ .LinkTitle }}</a>
+  {{ end }}
+</p>
+{{ end }}


### PR DESCRIPTION
This is done because the default config for the theme depends on the word 'blog' and could not handle the Norwegian word 'blogg'.