### PR TITLE
[Fix] Tags for Blog Posts and Configure Permalinks for the Blog Page

### DIFF
--- a/content/blogg/hello-world.md
+++ b/content/blogg/hello-world.md
@@ -1,6 +1,8 @@
 ---
 title: "Hello World!"
 date: 2023-11-02
+tags:
+  - setup
 ---
 
 Dette er det første innlegget på siden min, som også vil fungere som en blogg. Jeg er ikke helt sikker på hva målet med siden er ennå, men forhåpentligvis vil det utvikle seg til noe interessant.

--- a/hugo.toml
+++ b/hugo.toml
@@ -17,6 +17,11 @@ pluralizeListTitles = false
 # Generate a nice robots.txt for SEO
 enableRobotsTXT = true
 
+# Configuration for permalinks in Hugo.
+[permalinks]
+  blog = "/:filename/"
+  tags = "/blogg/:slug"
+
 [params]
   # The "description" of your website. This is used in the meta data of your generated html.
   description = "Hugo + Bear = :heart:"

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,0 +1,38 @@
+{{ define "main" }}
+<content>
+  {{ if .Data.Singular }}
+  <h3 style="margin-bottom:0">Filtering for "{{ .Title }}"</h3>
+  <small>
+    <a href="{{ "blogg" | relURL }}">Remove filter</a>
+  </small>
+  {{ end }}
+  <ul class="blog-posts">
+    {{ range .Pages }}
+    <li>
+      <span>
+        <i>
+          <time datetime='{{ .Date.Format "2006-01-02" }}' pubdate>
+            {{ .Date.Format (default "02 Jan, 2006" .Site.Params.dateFormat) }}
+          </time>
+        </i>
+      </span>
+      <a href="{{ .Permalink }}">{{ .Title }}</a>
+    </li>
+    {{ else }}
+    <li>
+      No posts yet
+    </li>
+    {{ end }}
+  </ul>
+  {{ if .Data.Singular }}
+  {{else}}
+    <small>
+      <div>
+        {{ range .Site.Taxonomies.tags }}
+        <a href="{{ .Page.Permalink }}">#{{ .Page.Title }}</a>&nbsp;
+        {{ end }}
+      </div>
+    </small>
+    {{ end }}
+</content>
+{{ end }}


### PR DESCRIPTION
This PR implements a fix for the tags and filtering functionality, the problem was that Remove Filter in `list.html` had a hard coded `href` with the value `blog`. I created my own custom layout and changed the value to `blogg` so that the link navigated to the correct page.

I also added some permalink configuration and a tag for the 'hello world' post.