### PR TITLE
[Fix] Deprecation of author key after upgrading Hugo version

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -10,11 +10,8 @@ pluralizeListTitles = false
 
 # Basic metadata configuration for your blog.
 title = 'omlarsen'
-copyright = "Copyright © 2024, Ole Martin Larsen."
+copyright = "Copyright © 2025, Ole Martin Larsen."
 languageCode = 'nb'
-[author]
-name = "Ole Martin Larsen"
-email = "ole@omlarsen.no"
 
 # Generate a nice robots.txt for SEO
 enableRobotsTXT = true
@@ -53,3 +50,7 @@ hideMadeWithLine = true
 # for details. An example TOML config that uses [ISO
 # 8601](https://en.wikipedia.org/wiki/ISO_8601) format:
 dateFormat = "2006-01-02"
+
+  [params.author]
+    name = "Ole Martin Larsen"
+    email = "ole@omlarsen.no"

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -6,8 +6,8 @@
     <description>Blogg poster fra {{ .Site.Title }}</description>
     <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
     <language>{{.}}</language>{{end}}
-    <managingEditor>{{ $.Site.Author.name }} ({{ $.Site.Author.email }})</managingEditor>
-    <webMaster>{{ $.Site.Author.name }} ({{ $.Site.Author.email }})</webMaster>{{ with .Site.Copyright }}
+    <managingEditor>{{ $.Site.Params.author.name }} ({{ $.Site.Author.email }})</managingEditor>
+    <webMaster>{{ $.Site.Params.author.name }} ({{ $.Site.Author.email }})</webMaster>{{ with .Site.Copyright }}
     <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
     <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006" | safeHTML }}</lastBuildDate>{{ end }}
     {{ with .OutputFormats.Get "RSS" }}
@@ -17,8 +17,8 @@
     <item>
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>
-      <pubDate>{{ .Date.Format "Monday, 02 January 2006" | safeHTML }} - {{ $.Site.Author.name }}</pubDate>
-      <author>{{ $.Site.Author.name }} ({{ $.Site.Author.email }})</author>
+      <pubDate>{{ .Date.Format "Monday, 02 January 2006" | safeHTML }} - {{ $.Site.Params.author.name }}</pubDate>
+      <author>{{ $.Site.Params.author.name }} ({{ $.Site.Author.email }})</author>
       <guid>{{ .Permalink }}</guid>
       <description>{{ .Summary | html }}</description>
     </item>


### PR DESCRIPTION
There were a breaking change when upgrading Hugo beyond version _0.126.1_, the `author` key in site configuration was deprecated. The fix is to use `params.author.name` instead.

See: https://harrycresswell.com/writing/upgrading-hugo-warnings-breaking-changes/